### PR TITLE
Update `serialize` method to not inlcuded empty compartments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+* Allow Embedded fields to marked as not required (mattupstate)
 * Field order is preserved in serialized documents (mattupstate)
 
 1.0.0

--- a/tests/serialize/test_complex_type.py
+++ b/tests/serialize/test_complex_type.py
@@ -105,3 +105,15 @@ def test_creation_counter():
     rv = json.dumps(serialized)
     assert rv == ('{"_links": {"self": {"href": "http://somewhere.com"}}, "hello": "world", '
                   '"foo": "bar", "_embedded": {"person": {"name": "John", "surname": "Smith"}}}')
+
+
+def test_empty_compartment_does_not_appear():
+    """Test that an empty compartment does not appear in a serialized document."""
+
+    class Schema(halogen.Schema):
+        user1 = halogen.Embedded(PersonSchema, required=False)
+        user2 = halogen.Embedded(PersonSchema)
+
+    serialized = Schema.serialize({'user2': Person("John", "Smith")})
+    rv = json.dumps(serialized)
+    assert rv == '{"_embedded": {"user2": {"name": "John", "surname": "Smith"}}}'


### PR DESCRIPTION
Here's an updated PR to allow for embedded documents to not be required. This also ensures that empty compartments are not included in a serialized document.
