### PR TITLE
Strict validation of the ISO8601

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.3.2
 -----
 
+* Strict validation of the ISO8601 (olegpidsadnyi)
+
+1.3.2
+-----
+
 * Improve serialization performance (youtux)
 
 

--- a/halogen/__init__.py
+++ b/halogen/__init__.py
@@ -1,6 +1,6 @@
 """halogen public API."""
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 
 try:
     from halogen.schema import Schema, attr, Attr, Link, Curie, Embedded, Accessor

--- a/halogen/types.py
+++ b/halogen/types.py
@@ -2,6 +2,7 @@
 import datetime
 import decimal
 
+import dateutil.parser
 import isodate
 import pytz
 import six
@@ -10,7 +11,6 @@ from .exceptions import ValidationError
 
 
 class Type(object):
-
     """Base class for creating types."""
 
     def __init__(self, validators=None, *args, **kwargs):
@@ -46,7 +46,6 @@ class Type(object):
 
 
 class List(Type):
-
     """List type for Halogen schema attribute."""
 
     def __init__(self, item_type=None, allow_scalar=False, *args, **kwargs):
@@ -83,7 +82,6 @@ class List(Type):
 
 
 class ISOUTCDateTime(Type):
-
     """ISO-8601 datetime schema type in UTC timezone."""
 
     type = "datetime"
@@ -103,6 +101,7 @@ class ISOUTCDateTime(Type):
     def deserialize(self, value, **kwargs):
         value = value() if callable(value) else value
         try:
+            dateutil.parser.parse(value)
             value = getattr(isodate, "parse_{0}".format(self.type))(value)
         except (isodate.ISO8601Error, ValueError):
             raise ValueError(self.message.format(val=value))
@@ -111,7 +110,6 @@ class ISOUTCDateTime(Type):
 
 
 class ISOUTCDate(ISOUTCDateTime):
-
     """ISO-8601 date schema type in UTC timezone."""
 
     type = "date"
@@ -119,7 +117,6 @@ class ISOUTCDate(ISOUTCDateTime):
 
 
 class String(Type):
-
     """String schema type."""
 
     def serialize(self, value, **kwargs):
@@ -134,7 +131,6 @@ class String(Type):
 
 
 class Int(Type):
-
     """Int schema type."""
 
     def serialize(self, value, **kwargs):
@@ -149,7 +145,6 @@ class Int(Type):
 
 
 class Boolean(Type):
-
     """Boolean schema type."""
 
     def serialize(self, value, **kwargs):
@@ -173,7 +168,6 @@ class Boolean(Type):
 
 
 class Amount(Type):
-
     """Amount (money) schema type."""
 
     err_unknown_currency = "'{currency}' is not a valid currency."

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,11 @@ from setuptools.command.test import test as TestCommand
 import halogen
 
 install_requires = [
+    'cached-property',
     'isodate',
+    'python-dateutil',
     'pytz',
     'six',
-    'cached-property',
 ]
 
 try:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -44,12 +44,19 @@ def test_isodatetime_bc():
     assert type_.deserialize('1799-12-31T23:00:00Z') == value.replace(microsecond=0)
 
 
-def test_isodatetime_wrong():
+@pytest.mark.parametrize(
+    "value",
+    [
+        "01.01.1981 11:11:11",
+        "123x3",
+    ],
+)
+def test_isodatetime_wrong(value):
     """Test iso datetime when wrong value is passed."""
     type_ = types.ISOUTCDateTime()
     with pytest.raises(ValueError) as err:
-        type_.deserialize("01.01.1981 11:11:11")
-    assert err.value.args[0] == "'01.01.1981 11:11:11' is not a valid ISO-8601 datetime"
+        type_.deserialize(value)
+    assert err.value.args[0] == "'{0}' is not a valid ISO-8601 datetime".format(value)
 
 
 def test_isodate():


### PR DESCRIPTION
isodate parses everything even 123xyz as 1200-01-01, which doesn't seem an ISO8601. Added another validation with the python-dateutil parsing.