### PR TITLE
Add type ISODateTime

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.3.5
+-----
+
+* Add ISO Date Time type (moisesribeiro)
+
+
 1.3.4
 -----
 

--- a/halogen/__init__.py
+++ b/halogen/__init__.py
@@ -1,6 +1,6 @@
 """halogen public API."""
 
-__version__ = '1.3.4'
+__version__ = '1.3.5'
 
 try:
     from halogen.schema import Schema, attr, Attr, Link, Curie, Embedded, Accessor

--- a/halogen/types.py
+++ b/halogen/types.py
@@ -81,6 +81,26 @@ class List(Type):
         return result
 
 
+class ISODateTime(Type):
+    """ISO-8601 datetime schema type."""
+
+    type = "datetime"
+    message = u"'{val}' is not a valid ISO-8601 datetime"
+
+    def serialize(self, value, **kwargs):
+        return value.isoformat() if value else None
+
+    def deserialize(self, value, **kwargs):
+        value = value() if callable(value) else value
+        try:
+            dateutil.parser.parse(value)
+            value = getattr(isodate, "parse_{0}".format(self.type))(value)
+        except (isodate.ISO8601Error, ValueError):
+            raise ValueError(self.message.format(val=value))
+
+        return super(ISODateTime, self).deserialize(value)
+
+
 class ISOUTCDateTime(Type):
     """ISO-8601 datetime schema type in UTC timezone."""
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,6 +8,7 @@ import six
 import mock
 import pytest
 
+from pytz import timezone
 from halogen import types
 
 
@@ -27,7 +28,22 @@ def test_list():
     assert value == type_.deserialize(value)
 
 
-def test_isodatetime():
+@pytest.mark.parametrize(
+    ["value", "serialized"],
+    [
+        (timezone('Europe/Amsterdam').localize(datetime.datetime(2018, 12, 23, 16, 20)), '2018-12-23T16:20:00+01:00'),
+        (timezone('Europe/Amsterdam').localize(datetime.datetime(2018, 5, 14, 16, 20)), '2018-05-14T16:20:00+02:00'),
+        (timezone('UTC').localize(datetime.datetime(2018, 5, 14, 16, 20)), '2018-05-14T16:20:00+00:00'),
+    ]
+)
+def test_isodatetime(value, serialized):
+    """Test iso datetime."""
+    type_ = types.ISODateTime()
+    assert type_.serialize(value) == serialized
+    assert type_.deserialize(serialized) == value.replace(microsecond=0)
+
+
+def test_isoutcdatetime():
     """Test iso datetime."""
     type_ = types.ISOUTCDateTime()
     value = datetime.datetime.now(pytz.timezone("CET")).astimezone(pytz.UTC)
@@ -36,7 +52,7 @@ def test_isodatetime():
     assert type_.deserialize(serialized) == value.replace(microsecond=0)
 
 
-def test_isodatetime_bc():
+def test_isoutcdatetime_bc():
     """Test iso datetime with year before 1900."""
     type_ = types.ISOUTCDateTime()
     value = datetime.datetime(1800, 1, 1, tzinfo=pytz.timezone("CET"))
@@ -51,7 +67,7 @@ def test_isodatetime_bc():
         "123x3",
     ],
 )
-def test_isodatetime_wrong(value):
+def test_isoutcdatetime_wrong(value):
     """Test iso datetime when wrong value is passed."""
     type_ = types.ISOUTCDateTime()
     with pytest.raises(ValueError) as err:


### PR DESCRIPTION
Greetings! 

Here is the branch to add ISODateTime to halogen types. 

The current date time type is ISO UTC date time that converts the date time to UTC before serializing it. 

The goal of ISO Date Time is to provide the offset (+00:00) from UTC instead. This could help me solve an issue with the google markup schema and hopefully be useful to others. 

Thanks for your time, 
Moises