### PR TITLE
Support kwargs in Schema.deserialize

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.5.0
+-----
+
+* Allow passing context keyword arguments to deserialize methods (blaise-io)
+
+
 1.4.1
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -1057,15 +1057,39 @@ as ``halogen.exceptions.ValidationError``. This is to eliminate the need of rais
 types and attributes during the deserialization.
 
 
-Deserialization context
-~~~~~~~~~~~~~~~~~~~~~~~
+Providing context
+~~~~~~~~~~~~~~~~~
 
-When deserializing an object, not all data required for deserializiation may be available in the object itself.
-You can pass this data as separate keyword parameters to ``deserialize`` to provide context. This context will be
-available in all nested schema, types and attributes.
+When serializing or deserializing an object, not all data required for (de)serialization may be available in the object
+itself. You can pass this data as separate keyword parameters to `serialize` or ``deserialize`` to provide context.
+This context will be available in all nested schema, types and attributes.
+
+Serialize example:
+
+.. code-block:: python
+
+    class ErrorSchema(halogen.Schema):
+        message = halogen.Attr(
+            attr=lambda error, language: error["message"][language]
+        )
+
+    error = ErrorSchema.serialize({
+        "message": {
+            "dut": "Ongeldig e-mailadres",
+            "eng": "Invalid email address"
+        }
+    }, language="dut")
+
+    print error
+
+Result:
+
+.. code-block:: python
+
+    {"message": "Ongeldig e-mailadres"}
 
 
-Example:
+Deserialize example:
 
 .. code-block:: python
 
@@ -1106,7 +1130,6 @@ Example:
     }, language="eng")
 
     print author
-
 
 Result:
 

--- a/README.rst
+++ b/README.rst
@@ -323,7 +323,7 @@ to decorate a method of the class to be a getter accessor.
     import halogen
 
     class ShoppingCartSchema(halogen.Schema):
-        
+
         @halogen.attr(AmountType(), default=None)
         def total(obj):
             return sum(
@@ -527,7 +527,7 @@ is not desired the type can be wrapped into `Nullable` type.
 
 
     class FreeProductSchema(halogen.Schema):
-        
+
         price_null = halogen.Attr(halogen.types.Nullable(AmountType()), attr="price")
         price_zero = halogen.Attr(AmountType(), attr="price")
 
@@ -1055,6 +1055,70 @@ Result:
 Note that should ``ValueError`` exception happen on the attribute deserialization, it will be caught and reraized
 as ``halogen.exceptions.ValidationError``. This is to eliminate the need of raising halogen specific exceptions in
 types and attributes during the deserialization.
+
+
+Deserialization context
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When deserializing an object, not all data required for deserializiation may be available in the object itself.
+You can pass this data as separate keyword parameters to ``deserialize`` to provide context. This context will be
+available in all nested schema, types and attributes.
+
+
+Example:
+
+.. code-block:: python
+
+    import halogen
+
+
+    class Book(halogen.Schema):
+
+        @halogen.attr()
+        def title(obj, language):
+            return obj['title'][language]
+
+    class Author(halogen.Schema):
+        name = halogen.Attr(attr='author.name')
+        books = halogen.Attr(
+            halogen.types.List(Book),
+            attr='author.books',
+        )
+
+    author = Author.deserialize({
+        "author": {
+            "name": "Roald Dahl",
+            "books": [
+                {
+                    "title": {
+                        "dut": "De Heksen",
+                        "eng": "The Witches"
+                    }
+                },
+                {
+                    "title": {
+                        "dut": "Sjakie en de chocoladefabriek",
+                        "eng": "Charlie and the Chocolate Factory"
+                    }
+                }
+            ]
+        }
+    }, language="eng")
+
+    print author
+
+
+Result:
+
+.. code-block:: python
+
+    {
+        "name": "Roald Dahl",
+        "books": [
+            {"title": "The Witches"},
+            {"title": "Charlie and the Chocolate Factory"}
+        ]
+    }
 
 
 Vendor media types

--- a/README.rst
+++ b/README.rst
@@ -1061,7 +1061,7 @@ Providing context
 ~~~~~~~~~~~~~~~~~
 
 When serializing or deserializing an object, not all data required for (de)serialization may be available in the object
-itself. You can pass this data as separate keyword parameters to `serialize` or ``deserialize`` to provide context.
+itself. You can pass this data as separate keyword arguments to `serialize` or ``deserialize`` to provide context.
 This context will be available in all nested schema, types and attributes.
 
 Serialize example:

--- a/halogen/schema.py
+++ b/halogen/schema.py
@@ -182,7 +182,7 @@ class Attr(object):
 
         return self.attr_type
 
-    def deserialize(self, value):
+    def deserialize(self, value, **kwargs):
         """Deserialize the attribute from a HAL structure.
 
         Get the value from the HAL structure from the attribute's compartment
@@ -200,12 +200,13 @@ class Attr(object):
             compartment = value[self.compartment]
 
         try:
-            value = self.accessor.get(compartment)
+            value = self.accessor.get(compartment, **kwargs)
         except (KeyError, AttributeError):
             if not hasattr(self, "default") and self.required:
                 raise
             return self.default() if callable(self.default) else self.default
-        return self.attr_type.deserialize(value)
+
+        return self.attr_type.deserialize(value, **kwargs)
 
     def __repr__(self):
         """Attribute representation."""
@@ -412,7 +413,7 @@ class _Schema(types.Type):
         return result
 
     @classmethod
-    def deserialize(cls, value, output=None):
+    def deserialize(cls, value, output=None, **kwargs):
         """Deserialize the HAL structure into the output value.
 
         :param value: Dict of already loaded json which will be deserialized by schema attributes.
@@ -426,7 +427,7 @@ class _Schema(types.Type):
         result = {}
         for attr in cls.__attrs__.values():
             try:
-                result[attr.name] = attr.deserialize(value)
+                result[attr.name] = attr.deserialize(value, **kwargs)
             except NotImplementedError:
                 # Links don't support deserialization
                 continue

--- a/halogen/types.py
+++ b/halogen/types.py
@@ -26,14 +26,14 @@ class Type(object):
         """Serialization of value."""
         return value
 
-    def deserialize(self, value):
+    def deserialize(self, value, **kwargs):
         """Deserialization of value.
 
         :return: Deserialized value.
         :raises: :class:`halogen.exception.ValidationError` exception if value is not valid.
         """
         for validator in self.validators:
-            validator.validate(value)
+            validator.validate(value, **kwargs)
 
         return value
 

--- a/tests/deserialize/test_deserialize.py
+++ b/tests/deserialize/test_deserialize.py
@@ -19,3 +19,58 @@ def test_attr_decorator_setter():
     output = {}
     Schema.deserialize({"total": 555}, output=output)
     assert output["total"] == 321
+
+
+def test_deserialize_kwargs():
+    """Test that context is accessible in all attr variations"""
+
+    class Schema(halogen.Schema):
+        @halogen.attr()
+        def total_decorator(obj, custom_kwarg):
+            return obj['total'][custom_kwarg]
+
+        total_lambda = halogen.Attr(attr=lambda obj, custom_kwarg: obj['total'][custom_kwarg])
+
+        total_nested = halogen.Attr(
+            halogen.Schema(nested=halogen.Attr(attr='mykey')),
+            attr='total',
+        )
+
+        total_dot_sep_str = halogen.Attr(attr='total.mykey')
+
+    deserialized = Schema.deserialize(
+        {"total": {"mykey": 123}},
+        custom_kwarg='mykey'
+    )
+
+    assert deserialized["total_decorator"] == 123
+    assert deserialized["total_lambda"] == 123
+    assert deserialized["total_nested"]["nested"] == 123
+    assert deserialized["total_dot_sep_str"] == 123
+
+
+def test_deserialize_kwargs_list():
+    """Test that context is maintained across a list"""
+
+    class Schema(halogen.Schema):
+        @halogen.attr()
+        def total(obj, custom_kwarg):
+            return obj['total'][custom_kwarg]
+
+    class ListSchema(halogen.Schema):
+        deserialized_list = halogen.attr(halogen.types.List(Schema), attr='mylist')
+
+    deserialized = ListSchema.deserialize(
+        {
+            "mylist": [
+                {"total": {"mykey": 123}},
+                {"total": {"mykey": 234}},
+            ]
+        },
+        custom_kwarg='mykey'
+    )
+
+    assert deserialized['deserialized_list'] == [
+        {"total": 123},
+        {"total": 234},
+    ]

--- a/tests/serialize/test_simple.py
+++ b/tests/serialize/test_simple.py
@@ -69,3 +69,21 @@ def test_attr_decorator_getter():
 
     data = Schema.serialize({"total": 555})
     assert data["total"] == 123
+
+
+def test_context():
+    """Test passing context to serialize."""
+
+    class Error(halogen.Schema):
+        message = halogen.Attr(
+            attr=lambda error, language: error["message"][language]
+        )
+
+    error = Error.serialize({
+        "message": {
+            "dut": "Ongeldig e-mailadres",
+            "eng": "Invalid email address"
+        }
+    }, language="dut")
+
+    assert error == {"message": "Ongeldig e-mailadres"}


### PR DESCRIPTION
It would be useful to allow passing keyword arguments to Schema.deserialize to consider additional context that may not be available in the to-be-deserialized data itself.