### PR TITLE
Fix List raising the wrong errors (or not error at all)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,11 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     - id: black
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.2.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.7.0
+-----
+
+* Fix `List` type raising unrelated errors (or no error at all, when passing a dictionary) when deserializing objects that are not lists.
+
+
 1.6.1
 -----
 

--- a/halogen/__init__.py
+++ b/halogen/__init__.py
@@ -1,6 +1,6 @@
 """halogen public API."""
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"
 
 try:
     from halogen.schema import Schema, attr, Attr, Link, Curie, Embedded, Accessor

--- a/halogen/types.py
+++ b/halogen/types.py
@@ -64,8 +64,11 @@ class List(Type):
 
     def deserialize(self, value, **kwargs):
         """Deserialize every item of the list."""
-        if self.allow_scalar and not isinstance(value, (list, tuple)):
-            value = [value]
+        if not isinstance(value, (list, tuple)):
+            if self.allow_scalar:
+                value = [value]
+            else:
+                raise ValidationError('"{}" is not a list'.format(value))
         value = super(List, self).deserialize(value)
         result = []
         errors = []

--- a/tests/serialize/test_simple.py
+++ b/tests/serialize/test_simple.py
@@ -81,7 +81,8 @@ def test_context():
         message = halogen.Attr(attr=lambda error, language: error["message"][language])
 
     error = Error.serialize(
-        {"message": {"dut": "Ongeldig e-mailadres", "eng": "Invalid email address"}}, language="dut",
+        {"message": {"dut": "Ongeldig e-mailadres", "eng": "Invalid email address"}},
+        language="dut",
     )
 
     assert error == {"message": "Ongeldig e-mailadres"}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -69,9 +69,7 @@ def test_isoutcdatetime_bc():
     assert type_.deserialize("1799-12-31T23:00:00Z") == value.replace(microsecond=0)
 
 
-@pytest.mark.parametrize(
-    "value", ["01.01.1981 11:11:11", "123x3"],
-)
+@pytest.mark.parametrize("value", ["01.01.1981 11:11:11", "123x3"])
 def test_isoutcdatetime_wrong(value):
     """Test iso datetime when wrong value is passed."""
     type_ = types.ISOUTCDateTime()
@@ -187,7 +185,8 @@ def test_amount_serialize():
 def test_nullable_type():
 
     nested_type = mock.MagicMock(
-        serialize=mock.MagicMock(return_value="serialize"), deserialize=mock.MagicMock(return_value="deserialize"),
+        serialize=mock.MagicMock(return_value="serialize"),
+        deserialize=mock.MagicMock(return_value="deserialize"),
     )
 
     nullable = types.Nullable(nested_type)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -10,6 +10,7 @@ import pytest
 
 from pytz import timezone
 from halogen import types
+from halogen.exceptions import ValidationError
 
 
 def test_type():
@@ -26,6 +27,14 @@ def test_list():
     value = [object(), object()]
     assert value == type_.serialize(value)
     assert value == type_.deserialize(value)
+
+
+@pytest.mark.parametrize("input", [{"foo": "bar"}, 42, 11.5, True, False, None, "", "foo"])
+def test_list_bad_input(input):
+    """Test that the deserialization fails correctly when the input is not a list, and scalars are not allowed"""
+    type_ = types.List(allow_scalar=False)
+    with pytest.raises(ValidationError, match=".*is not a list"):
+        type_.deserialize(input)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The List type does not handle the input correctly when `allow_scalar=False`. This results in all sorts of exceptions being raised, while we should just raise a ValdiationError.
Also, in case of a dictionary value, it wouldn't raise any exception at all.

This PR addresses this issue by checking the type of the input.