### PR TITLE
Embedded validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.1.0
+-----
+
+* Added Embedded validation
+
+
 2.0.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,6 @@ Python HAL generation/parsing library.
     :target: https://travis-ci.org/paylogic/halogen
 .. image:: https://readthedocs.org/projects/halogen/badge/?version=latest
     :alt: Documentation Status
-    :scale: 100%
     :target: https://readthedocs.org/projects/halogen/
 
 Halogen takes the advantage of the declarative style serialization with easily extendable schemas.

--- a/halogen/__init__.py
+++ b/halogen/__init__.py
@@ -1,6 +1,6 @@
 """halogen public API."""
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 try:
     from halogen.schema import Schema, attr, Attr, Link, Curie, Embedded, Accessor

--- a/halogen/exceptions.py
+++ b/halogen/exceptions.py
@@ -45,3 +45,7 @@ class ValidationError(Exception):
 
 class ExcludedValueException(Exception):
     """Value was explicitly excluded, on serialize exclude this key"""
+
+
+class InvalidSchemaDefinition(Exception):
+    """Schema breaks the HAL standard"""

--- a/halogen/schema.py
+++ b/halogen/schema.py
@@ -398,21 +398,18 @@ class Embedded(Attr):
         return ":".join((self.curie.name, self.name))
 
     def validate(self):
-        #Validate self link
-        class_attributes = self.attr_type.__dict__.get("__class_attrs__")
-        if isinstance(self.attr_type, halogen.types.List):
-            class_attributes = self.attr_type.item_type.__dict__.get("__class_attrs__")
-        if class_attributes is not None and "self" not in class_attributes.keys():
-            raise InvalidSchemaDefinition("Invalid HAL standard definition, need `self` link")
-
-        #Validate attr_type of type schema
         attribute_type = self.attr_type
         if isinstance(attribute_type, halogen.types.List):
             attribute_type = attribute_type.item_type
 
+        #Validate attr_type of type schema
         if not isinstance(attribute_type, halogen.schema._SchemaType):
             raise InvalidSchemaDefinition("Invalid HAL standard definition, embedded values are either resource objects or list of resource objects")
 
+        #Validate self link
+        class_attributes = attribute_type.__dict__.get("__class_attrs__")
+        if class_attributes is not None and "self" not in class_attributes.keys():
+            raise InvalidSchemaDefinition("Invalid HAL standard definition, need `self` link")
 
 
 class _Schema(types.Type):

--- a/tests/unit/schema/attr/test_embedded.py
+++ b/tests/unit/schema/attr/test_embedded.py
@@ -1,0 +1,48 @@
+import pytest
+
+import halogen
+from halogen.exceptions import InvalidSchemaDefinition
+
+
+def test_invalid_embedded_validation():
+    class EmbeddedWithoutSelfReferenceSchema(halogen.Schema):
+        name = halogen.types.String()
+
+    class ValidEmbeddedSchema(halogen.Schema):
+        self = halogen.Link()
+
+    with pytest.raises(InvalidSchemaDefinition):
+        class TestSchema(halogen.Schema):
+            embedded_value = halogen.Embedded(EmbeddedWithoutSelfReferenceSchema)
+
+    with pytest.raises(InvalidSchemaDefinition):
+        class TestWithInvalidListSchema(halogen.Schema):
+            embedded_value = halogen.Embedded(halogen.types.List(halogen.types.String))
+
+    with pytest.raises(InvalidSchemaDefinition):
+        class TestWithEmptyListSchema(halogen.Schema):
+            embedded_value = halogen.Embedded(halogen.types.List())
+
+    with pytest.raises(InvalidSchemaDefinition):
+        class TestWithIncorrectValueSchema(halogen.Schema):
+            embedded_value = halogen.Embedded(halogen.types.String())
+
+
+def test_valid_embedded_validation():
+    class EmbeddedWithSelfReferenceSchema(halogen.Schema):
+        self = halogen.Link()
+
+    class EmbeddedWithSelfReferenceFunctionSchema(halogen.Schema):
+
+        @halogen.Link()
+        def self(self):
+            return "/foobar/1"
+
+    class TestSchema(halogen.Schema):
+        embedded_value = halogen.Embedded(EmbeddedWithSelfReferenceSchema)
+
+    class TestWithFunctionSchema(halogen.Schema):
+        embedded_value = halogen.Embedded(EmbeddedWithSelfReferenceFunctionSchema)
+
+    class TestWithListSchema(halogen.Schema):
+        embedded_value = halogen.Embedded(halogen.types.List(EmbeddedWithSelfReferenceFunctionSchema))


### PR DESCRIPTION
Embedded resources should always follow the HAL standard.
Added Embedded validation:

- Value is a halogen schema (not a type) and cannot be None
- Nested schema has a self-link